### PR TITLE
feat : config 서버 설정

### DIFF
--- a/src/main/java/com/goggles/config_server/ConfigServerApplication.java
+++ b/src/main/java/com/goggles/config_server/ConfigServerApplication.java
@@ -2,8 +2,10 @@ package com.goggles.config_server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.config.server.EnableConfigServer;
 
 @SpringBootApplication
+@EnableConfigServer
 public class ConfigServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -24,5 +24,4 @@ eureka:
     register-with-eureka: true
     fetch-registry: false        # config-server는 다른 서비스 목록 필요 없음
     service-url:
-      defaultZone: http://${EUREKA_SERVER_URL1:localhost}:9001/eureka/,
-        http://${EUREKA_SERVER_URL2:localhost}:9002/eureka/
+      defaultZone: http://${EUREKA_SERVER_URL1:localhost}:9001/eureka/,http://${EUREKA_SERVER_URL2:localhost}:9002/eureka/

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,6 +7,8 @@ spring:
         git:
           uri: https://github.com/9oogle/project-configs
           default-label: dev
+          clone-on-start: true
+          timeout: 5
           search-paths:
           - configs/**
           - configs/{application}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,26 @@
 spring:
   application:
-    name: config_server
+    name: config-server
+  cloud:
+    config:
+      server:
+        git:
+          uri: https://github.com/9oogle/project-configs
+          default-label: dev
+          search-paths:
+          - configs/**
+          - configs/{application}
+
+server:
+  port: 9011
+
+eureka:
+  instance:
+    prefer-ip-address: false
+    hostname: ${HOSTNAME:localhost}
+  client:
+    register-with-eureka: true
+    fetch-registry: false        # config-server는 다른 서비스 목록 필요 없음
+    service-url:
+      defaultZone: http://${EUREKA_SERVER_URL1:localhost}:9001/eureka/,
+        http://${EUREKA_SERVER_URL2:localhost}:9002/euraka/

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -23,4 +23,4 @@ eureka:
     fetch-registry: false        # config-server는 다른 서비스 목록 필요 없음
     service-url:
       defaultZone: http://${EUREKA_SERVER_URL1:localhost}:9001/eureka/,
-        http://${EUREKA_SERVER_URL2:localhost}:9002/euraka/
+        http://${EUREKA_SERVER_URL2:localhost}:9002/eureka/


### PR DESCRIPTION
- @EnableConfigServer 어노테이션 추가
- GitHub 저장소 연결, Eureka 등록

### 📌 관련 이슈
- close #3
### 💡 작업 내용
- @EnableConfigServer 어노테이션 추가
- GitHub 저장소 연결, Eureka 등록

### 🔍 변경 이유

### 📝 리뷰 포인트 (선택)
- 집중해서 봐줬으면 하는 부분

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 중앙집중식 설정 관리: Spring Cloud Config Server 활성화
  * 서비스 등록: Eureka 기반 자동 등록 활성화

* **설정 변경**
  * 애플리케이션명 표기 변경(config-server)
  * 내장 서버 포트를 9011로 지정
  * 원격 Git 저장소(dev 브랜치, 시작 시 복제, 검색 경로 포함)에서 구성 로드 설정 추가
  * Eureka 설정: 레지스트리 조회 비활성화, 복수 기본 Zone 주소 및 호스트명 환경변수 사용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->